### PR TITLE
Alteração no Auth,php para evitar que redirecione incorretamente

### DIFF
--- a/app/Filters/Auth.php
+++ b/app/Filters/Auth.php
@@ -11,7 +11,12 @@ class Auth implements FilterInterface
     public function before(RequestInterface $request, $arguments = null)
     {
         if ((bool)session()->isLoggedIn != true) {
-            return redirect()->to('/home');
+            if ($_SERVER['REQUEST_URI'] != "/") {
+                $URL = explode("/", $_SERVER["REDIRECT_URL"]);
+                if($URL[1] != 'Home') {
+                    return redirect()->to('/home');
+                };
+            }
         }
     }
 


### PR DESCRIPTION
Adicionei uma tratativa para que, mesmo que o usuário esteja deslogado, caso a URL seja igual a URL da home ou pertença ao controller Home, o Auth,php não redirecione o usuário para a página inicial, pois isso deixava o usuário preso em um loop sem conseguir usar as outras páginas.